### PR TITLE
Changed `npm run server` path

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "server": "node server.js",
+    "server": "node src/Backend/server.js",
     "dev-server": "nodemon src/Backend/server.js"
   },
   "eslintConfig": {


### PR DESCRIPTION
Motivation: `npm run server` is not finding server.js on Heroku. Previously used, nodemon, but it was a dev dependency and is not packaged in build

![image](https://user-images.githubusercontent.com/37993586/198136938-e7010c79-a19a-43f8-ae94-3fa146d377a0.png)

Solution: rewrite `npm run server` to use `node src/Backend/server.js` instead of `nodemon src/Backend/server.js`
